### PR TITLE
Add scripts to show difference in commits between vim plugin versions

### DIFF
--- a/hack/diff.sh
+++ b/hack/diff.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# Given a Pull request opened by Renovate for a package, find out the commit
+# hashes and their titles that have been added from the current version
+# (checked in the repo) to the commit that renovate wants to update it to.
+
+set -e
+
+if [[ -z "${GH_OAUTH_TOKEN}" ]]; then # zero-length check
+  echo "Github oauth token is not set, exiting"
+  exit 1
+fi
+
+pr_body=$(cat - | jq -r '.body')
+
+# The repo name looks like
+# [ojroques/vim-oscyank](https://togithub.com/ojroques/vim-oscyank), but since
+# a regex will match all urls, look after a | in the beginning to only match
+# the repo (the repo is shown in a markdown table, which start with a |)
+repo_name=$(echo "$pr_body" | gawk 'match($0, "\\| \\[(.*\\/.*)\\]\\(", a) {print a[1]}')
+echo '----------------------------------------'
+echo "Looking for commits in '$repo_name' repo"
+printf '\n'
+
+# The commit text looks like `23b0846` -> `ebcb47d`
+basehead=$(echo "$pr_body" | gawk 'match($0, "`(.*)` -> `(.*)`", a) {printf "%s...%s",a[1],a[2]}')
+
+
+diff=$(curl -L -s --header "Authorization: token $GH_OAUTH_TOKEN" "https://api.github.com/repos/$repo_name/compare/$basehead")
+# Query commits since, and extract sha and commit message. Sometimes commits
+# can be multiline, the gsub removes everything after the newline so only the
+# title is shown
+commits=$(echo "$diff"| jq '.commits[].commit | "\(.tree.sha): \(.message | gsub("\\n(.*)"; "") )"')
+
+echo "$commits"

--- a/hack/pull_checker.sh
+++ b/hack/pull_checker.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# For every open pull request by Renovate in the repo, find out the difference
+# in commits.
+
+set -e
+
+if [[ -z "${GH_OAUTH_TOKEN}" ]]; then # zero-length check
+  echo "Github oauth token is not set, exiting"
+  echo "Get it by running the following"
+  printf '\n> export GH_OAUTH_TOKEN=$(gh config get -h github.com oauth_token)'
+  exit 1
+fi
+
+pull_reqs=$(curl -s --header "Authorization: token $GH_OAUTH_TOKEN" "https://api.github.com/repos/enniomara/dotfiles/pulls" )
+pull_requests_ids=$(echo "$pull_reqs" | jq '.[].number')
+
+for id in $pull_requests_ids
+do
+    curl -s --header "Authorization: token $GH_OAUTH_TOKEN" "https://api.github.com/repos/enniomara/dotfiles/pulls/$id" | ./diff.sh
+done
+


### PR DESCRIPTION
These scripts act on a given pull request opened by renovate, where the PR updates a neovim plugin. The problem with these updates is that it's difficult for me to find out about breaking changes without having to update the plugin manually or manually going to the repo and doing a diff.
These scripts will output something like:

```
Looking for commits in 'numToStr/Comment.nvim' repo                                                                                                                                                                                         
"f39ba5851376a4b0b21686207ec122c5251375af: feat: add `cabal` support (#156)"
"76a2990714d121ce2b8052b8e25ed8473c959675: feat: add `R` suppport (#165)" 
```